### PR TITLE
Allow to emit invalid utf-8 scalar strings

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -843,7 +843,6 @@ yaml_scalar_event_initialize(yaml_event_t *event,
         length = strlen((char *)value);
     }
 
-    if (!yaml_check_utf8(value, length)) goto error;
     value_copy = YAML_MALLOC(length+1);
     if (!value_copy) goto error;
     memcpy(value_copy, value, length);


### PR DESCRIPTION
Currently, the YAML emitter bluntly refuses to encode a scalar unless it's a valid utf-8 string (`yaml_scalar_event_initialize` fails if `yaml_check_utf8` returns false). To workaround this limitation in Tarantool, we encode invalid utf-8 strings as binary data (base64). This is confusing because we implicitly convert a string object to a binary object. When we introduce the binary data type to the Tarantool Lua interpreter, this might result in unexpected string to binary conversions.

Let's fix this limitation in the YAML emitter by encoding any byte sequences invalid from the point of utf-8 as `\xFF`. To achieve that, we do the following changes:

 - Remove `yaml_check_utf8` from `yaml_scalar_event_initialize`.
 - Introduce the `yaml_utf8_get_code_point` helper that carefully (respecting the input string boundaries) checks if the current character starts a valid utf-8 sequence and returns its code. The implementation was copied from `yaml_check_utf8`.
 - Remove all unnecessary checks from `yaml_emitter_is_printable` and rename it to `yaml_utf8_is_printable`. Since this function already uses the powerful `u_isprint` from libicu, we need only one extra check - whether the given code point is a line break because line breaks are emitted without escaping for plain and single-quoted scalar types.
 - Use `yaml_utf8_get_code_point` and `yaml_utf8_is_printable` in `yaml_analyze_scalar` and `yaml_emitter_write_double_quoted_scalar`. Be extra careful in `yaml_analyze_scalar` - don't access a character in the string unless it was checked by `yaml_utf8_get_code_point`. To achive that we have to rework the loop iterating over the input string characters in `yaml_analyze_scalar` so that it doesn't access the next character to set the `followed_by_whitespace` flag.
 - Factor out the code that emits a code point number to the separate helper function `yaml_emitter_write_code_point` and use this function to emit invalid utf-8 byte sequences. While we are at it, we also fix this code to correctly emit multi-byte utf-8 sequences with a single-byte code: currently they are emitted as `\xFF`, which is wrong; after this patch they are emitted as `\uFFFF` as they should be (this is important - for example, `\u0080` is equivalent to `\xc280`, not `\x80`).

After this change, we can remove all utf-8 checks from the Tarantool source code.

Needed for tarantool/tarantool#8756
Related PR https://github.com/tarantool/tarantool/pull/8786