### PR TITLE
Fix decoding single-byte char codes >= 0x80

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -3239,7 +3239,7 @@ yaml_parser_scan_flow_scalar(yaml_parser_t *parser, yaml_token_t *token,
                         goto error;
                     }
 
-                    if (value <= 0x7F) {
+                    if (value <= 0x7F || code_length == 2) {
                         *(string.pointer++) = value;
                     }
                     else if (value <= 0x7FF) {


### PR DESCRIPTION
A single-byte character code >= 0x80 is decoded as a two-byte UTF-8 code point (e.g. `\x80` => `\xC2\x80`, which is equivalent to  `\u0080`). Fix this by taking into account the code length.

Needed for tarantool/tarantool#8782
Related PR https://github.com/tarantool/tarantool/pull/8827